### PR TITLE
Add tightlist to plos template.

### DIFF
--- a/manuscript/resources/plos_template.tex
+++ b/manuscript/resources/plos_template.tex
@@ -148,6 +148,10 @@
 
 \newcommand{\lorem}{{\bf LOREM}}
 \newcommand{\ipsum}{{\bf IPSUM}}
+% The below needed to build markdown documents containing lists with pandoc
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}
+}
 
 %% END MACROS SECTION
 


### PR DESCRIPTION
From #65 

> I get an error with parsing lists on my machine with pandoc 1.15.0.6
> 
> ```
> [1]
> ! Undefined control sequence.
> l.259 \tightlist
> ```

This fixes the issue on my machine.
